### PR TITLE
Pass `initcode` to `value` directly

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,6 +1,6 @@
 fn main(){
-	println!("Hello!");
+	println!("Hello!🦀");
+	println!("カニだよ!"); // This is a club.
 	println!("Update me");
 	println!("Press Enter to update");
 }
-

--- a/examples/typescript_deno.jl
+++ b/examples/typescript_deno.jl
@@ -71,8 +71,39 @@ let
     end
 end
 
+# ╔═╡ 431a424b-c2bd-4083-89bc-29cee73c3dec
+md"""
+Note that the following code runs behind the scenes
+
+```julia
+let
+    shouldrun = false
+    if !ismissing(sourcecode)
+        if initCode != sourcecode
+            # Update file
+            write(targetfile, sourcecode)
+            # If updated, we should run code
+            shouldrun = true
+        end
+        if shouldrun
+            mktempdir() do d
+                write(joinpath(d, targetfile), sourcecode)
+				deno = Deno_jll.deno()
+                try
+                    run(`$(deno) run $(joinpath(d, targetfile))`)
+                catch e
+                    e isa ProcessFailedException || rethrow(e)
+                end
+            end
+        end
+    end
+end
+```
+"""
+
 # ╔═╡ Cell order:
 # ╟─9aa40f8c-a955-47a3-8e6d-4ac54d1dc330
 # ╠═07ebdbbe-49bb-4d18-9f2b-14f98d137548
 # ╠═bf232d99-3001-4aac-afb7-1321c7407666
-# ╠═dce616d7-fdfe-4854-919d-420603ebc875
+# ╟─dce616d7-fdfe-4854-919d-420603ebc875
+# ╟─431a424b-c2bd-4083-89bc-29cee73c3dec

--- a/src/PlutoMonacoEditor.jl
+++ b/src/PlutoMonacoEditor.jl
@@ -25,19 +25,10 @@ function MonacoEditor(
    	<div id='monaco-editor-container' class='pluto-monaco-editor'></div>
 
    <script>
-   	function decodeBase64(base64String) {
-   	    const prefix = "data:text/plain;base64,";
-   	    if (base64String.startsWith(prefix)) {
-   	        base64String = base64String.slice(prefix.length);
-   	    }
-   	    const decodedData = atob(base64String);
-   	    return decodedData;
-   	}
-
    	const monaco = await import('https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/+esm');
     	
    	const monEditor = monaco.editor.create(document.getElementById('monaco-editor-container'), {
-   		value: decodeBase64($(base64encode(initCode))),
+   		value: $(initCode),
    		language: $(language),
    		theme: $(theme)
    	});


### PR DESCRIPTION
I found that we do not have to write `decodeBase64($(base64encode(initCode))),`. We only have to pass `initCode` directly. The current implementation can't parse `🦀` properly. This PR fixes the bug.