### PR TITLE
Update JET compat and lint invocation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ HypertextLiteral = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
 Aqua = "0.8.9"
 Base64 = "1"
 HypertextLiteral = "0.9.5"
-JET = "0.9.12"
+JET = "0.9, 0.10, 0.11"
 Test = "1"
 julia = "1"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,6 @@ v = VERSION
 isreleased = v.prerelease == ()
 if isreleased && v >= v"1.10"
     @testset "Code linting (JET.jl)" begin
-        JET.test_package(PlutoMonacoEditor; target_defined_modules = true)
+        JET.test_package(PlutoMonacoEditor; target_modules = (PlutoMonacoEditor,))
     end
 end


### PR DESCRIPTION
## Summary
- broaden JET compatibility in `Project.toml` to support `0.9`, `0.10`, and `0.11`
- update `JET.test_package` call to use `target_modules` for newer JET API compatibility
- keep lint checks working across supported Julia/JET environments

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'`

Made with [Cursor](https://cursor.com)